### PR TITLE
Coins bug fix

### DIFF
--- a/Untitled Game/src/Actors/Actor.gd
+++ b/Untitled Game/src/Actors/Actor.gd
@@ -31,8 +31,9 @@ onready var hurtbox: Area2D = $HurtBox
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	errorLogger.assertNodeNotNull(kinematicSprite, "KinematicSprite", self)
-	errorLogger.assertNodeNotNull(hurtbox, "HurtBox", self)
-	_originalHurtBoxPosition = hurtbox.position
+	errorLogger.assertNodeNotNullNonCrashing(hurtbox, "HurtBox", self)
+	if hurtbox != null:
+		_originalHurtBoxPosition = hurtbox.position
 
 
 func _physics_process(delta):

--- a/Untitled Game/src/Helpers/Utilities/ErrorLogger.gd
+++ b/Untitled Game/src/Helpers/Utilities/ErrorLogger.gd
@@ -11,3 +11,9 @@ func _ready():
 func assertNodeNotNull(node: Node, nameOfNode: String, parentNode: Node):
 	var errorMessage = "Make sure " + nameOfNode + " exists in " + parentNode.get_name()
 	assert(node, errorMessage)
+
+
+func assertNodeNotNullNonCrashing(node: Node, nameOfNode: String, parentNode: Node):
+	var errorMessage = "Make sure " + nameOfNode + " exists in " + parentNode.get_name()
+	if !node:
+		printerr(errorMessage)

--- a/Untitled Game/src/Logic/LevelGlobals.gd
+++ b/Untitled Game/src/Logic/LevelGlobals.gd
@@ -59,6 +59,7 @@ func CreatePlayerSave(player : Actor) -> Dictionary:
 
 func SetCheckpoint(level, checkpointKey):
 	assert(_player_data != null, "Player data is null!")
+	_player_data = CreatePlayerSave(_player)
 	_player_data.level = level;
 	_player_data.checkpoint = checkpointKey;
 	save_game();


### PR DESCRIPTION
Coins will now be saved properly into save file.  Also debug game will no longer crash, when granny spawns

Save logic never got updates coin count and health. Should do so now. 

Granny crash caused by assert HurtBox call in actor. No longer do assert so it shouldnt crash when granny spawns. 