### PR TITLE
Fixed bug with death animation getting cut short

### DIFF
--- a/Untitled Game/src/Actors/Actor.gd
+++ b/Untitled Game/src/Actors/Actor.gd
@@ -108,7 +108,6 @@ func getMovement(direction: Vector2, speed: float, acceleration: float) -> Vecto
 	
 func take_damage(damage: int, direction: Vector2, force: float) -> void:
 	if !isDying:
-		_animationHandler.hurt()
 		var newHealth = _health-damage
 		emit_signal("health_changed", _health, newHealth, _maxHealth)
 		_health=newHealth
@@ -117,6 +116,8 @@ func take_damage(damage: int, direction: Vector2, force: float) -> void:
 		_velocity = move_and_slide(knockbackVelocity)
 		if(_health <= 0):
 			die()
+		else:
+			_animationHandler.hurt()
 		
 func die() -> void:
 	isDying = true

--- a/Untitled Game/src/Actors/MainChar/MainChar.gd
+++ b/Untitled Game/src/Actors/MainChar/MainChar.gd
@@ -119,21 +119,22 @@ func _setup_timer(timer: Timer, callback_name: String):
 
 
 func _physics_process(_delta: float) -> void:
-	._physics_process(_delta)
-	var direction = Vector2.ZERO
-	
-	_assign_player_color()
-	
-	if(!_attackManager.isAttacking and !_isDodging):
-		direction = evaluatePlayerInput(_delta)
-		_dodgeDirection = direction
+	if !isDying:
+		._physics_process(_delta)
+		var direction = Vector2.ZERO
 		
-	if _isDodging:
-		_velocity = getMovement(_dodgeDirection, _DODGE_SPEED, _DODGE_ACCELERATION)
-		_velocity = move_and_slide(_velocity)
-	elif !_beingHurt:
-		_velocity = getMovement(direction, _speed, _acceleration)
-		_velocity = move_and_slide(_velocity)
+		_assign_player_color()
+		
+		if(!_attackManager.isAttacking and !_isDodging):
+			direction = evaluatePlayerInput(_delta)
+			_dodgeDirection = direction
+			
+		if _isDodging:
+			_velocity = getMovement(_dodgeDirection, _DODGE_SPEED, _DODGE_ACCELERATION)
+			_velocity = move_and_slide(_velocity)
+		elif !_beingHurt:
+			_velocity = getMovement(direction, _speed, _acceleration)
+			_velocity = move_and_slide(_velocity)
 
 
 func _assign_player_color():
@@ -272,7 +273,6 @@ func take_damage(damage: int, direction: Vector2, force: float) -> void:
 		_beingHurt = true
 		_attackManager.gotHit()
 		_hitDoneTimer.start(_hitAnimationTime)
-		_animationHandler.hurt()
 		_invincibilityTimer.start(3)
 		var finalDamage = ceil(damage * _takeDamageModifier)
 		if isInfiniteHealth:


### PR DESCRIPTION
I think new blend tree can cut animations short. Put
check to not do any physics process if dying to keep
death animation playing