### PR TITLE
Another camera work

### DIFF
--- a/Untitled Game/addons/GGS/settings_data.json
+++ b/Untitled Game/addons/GGS/settings_data.json
@@ -75,7 +75,7 @@
 			"value": true
 		},
 		"current": {
-			"value": false
+			"value": true
 		},
 		"logic": "res://src/Helpers/Settings/Display_Vsync.gd"
 	},

--- a/Untitled Game/src/Actors/MainChar/LirikYaki.gd
+++ b/Untitled Game/src/Actors/MainChar/LirikYaki.gd
@@ -3,8 +3,8 @@ extends MainChar
 class_name LirikYaki
 
 func _ready() -> void:
-	$Light2D.visible = false;
-	$Light2DMask.visible = false;
+	#$Light2D.visible = false;
+	#$Light2DMask.visible = false;
 	_attackManager = AttackManager.new(_attackResetTimer,
 		chargeBar, _animationHandler)
 

--- a/Untitled Game/src/Helpers/Camera/CustomCamera2D.gd
+++ b/Untitled Game/src/Helpers/Camera/CustomCamera2D.gd
@@ -86,25 +86,25 @@ func _init(cameraTarget: Node, current: bool):
 func _ready():
 	self.set_process(true)
 
-func _process(delta: float):
+func _process(_delta: float):
 	if _zoomToPlayer:
-		_zoomToPlayer(delta)
+		_zoomToPlayer(_delta)
 	elif _zoomToAreaLock:
-		_zoomtToArenaLock(delta)
+		_zoomtToArenaLock(_delta)
 	elif _checkForRegularCameraBoundLimitSmoothing():
-		var cameraReachedTarget = _checkAndMoveCameraToTarget(delta)
-		var limitsReachedTarget = _checkAndMoveCameraLimitBounds(delta)
+		var cameraReachedTarget = _checkAndMoveCameraToTarget(_delta)
+		var limitsReachedTarget = _checkAndMoveCameraLimitBounds(_delta)
 		if cameraReachedTarget and limitsReachedTarget:
 			reachedCameraTarget()
 	elif _checkForPanToTarget():
 		var panTargetPosition = _panTarget.getPosition()
 		var distanceToTarget = self.position.distance_to(panTargetPosition)
-		self.position = lerp(self.get_global_position(), panTargetPosition,  delta * _panTarget._speed * abs(log(distanceToTarget)))
-		self.zoom = lerp(self.zoom, _panTarget._zoom , (delta * _panTarget._zoomSpeed) / distanceToTarget) #formula can/must be improved
+		self.position = lerp(self.get_global_position(), panTargetPosition,  _delta * _panTarget._speed * abs(log(distanceToTarget)))
+		self.zoom = lerp(self.zoom, _panTarget._zoom , (_delta * _panTarget._zoomSpeed) / distanceToTarget) #formula can/must be improved
 		if _panTarget._clearTimer == null and distanceToTarget < _CAMERA_DISTANCE_TARGET: #magic number that works well enough for now
 			yield(_panTarget.startPanTimer(), "timeout")
 			clearPan()
-	_handleShake(delta)
+	_handleShake(_delta)
 
 
 func _zoomToPlayer(delta: float):


### PR DESCRIPTION
Issue is caused by moving the camera bounds limit. Since after arena lock fight, it will try to move to outer level delimiter. Issue with that I think, is that outer camera delimiter is fairly larger compared to all other delimiters so it will take a while to move those bounds. 

During this state camera will try to also keep up with player while moving bounds, which causes weird stuttering. My hack is to make 1 seconds timer, so that after one seconds it will stop incrementally adjusting bounds, and instead assign the proper bounds to player and enable player camera tracking mode. 

i also added calculations based on delta for camera movements so that its same behaviour for different FPS. 