### PR TITLE
menu cant be activated on death until level restart

### DIFF
--- a/Untitled Game/src/Helpers/GUI/Pause/PauseScreenContainer.gd
+++ b/Untitled Game/src/Helpers/GUI/Pause/PauseScreenContainer.gd
@@ -10,6 +10,7 @@ signal settings_changed
 const _MENU_EVENT: String = "Menu"
 
 var _menuOpen = false
+var _dontOpenMenu = false # mostly used for when player is dying and screen goes black
 
 onready var pause_menu: PauseMenu = $PauseMenu
 onready var settings_menu: SettingsMenu = $SettingsMenu
@@ -29,9 +30,9 @@ func _switchMenu(showMenu: int):
 
 # node to handle player input, and call the proper response
 func _input(event: InputEvent) -> void:
-	if event.is_action_pressed(_MENU_EVENT) and !_isMenuOpen():
+	if event.is_action_pressed(_MENU_EVENT) and !_isMenuOpen() and !_dontOpenMenu:
 		_pauseAndShowMenu()
-	elif event.is_action_pressed(_MENU_EVENT) and _isMenuOpen():
+	elif event.is_action_pressed(_MENU_EVENT) and _isMenuOpen() and !_dontOpenMenu:
 		_unpauseAndHideMenu()
 
 func _pauseAndShowMenu() -> void:
@@ -57,3 +58,7 @@ func _on_settings_changed():
 
 func _isMenuOpen() -> bool:
 	return pause_menu.visible || settings_menu.visible
+
+
+func _on_player_died():
+	_dontOpenMenu = true

--- a/Untitled Game/src/Levels/House.tscn
+++ b/Untitled Game/src/Levels/House.tscn
@@ -2644,6 +2644,7 @@ margin_bottom = -6.10352e-05
 [connection signal="interactable_text_signal" from="LevelBackground/Interactions/Garage/lawnmower" to="." method="_on_InteractPromptArea_interactable_text_signal"]
 [connection signal="interactable_text_signal" from="LevelBackground/Interactions/Garage/tools" to="." method="_on_InteractPromptArea_interactable_text_signal"]
 [connection signal="body_exited" from="LevelBackground/Teleports/Bathroom_Bedroom_2WT/EndpointAlpha" to="." method="_on_BathroomToBedroom_body_exited"]
+[connection signal="died" from="YSort/Actors/LirikYaki" to="GUI/PauseScreenContainer" method="_on_player_died"]
 [connection signal="item_delete" from="YSort/Actors/LirikYaki" to="." method="_on_LirikYaki_item_delete"]
 [connection signal="item_pickup" from="YSort/Actors/LirikYaki" to="." method="_on_LirikYaki_item_pickup"]
 [connection signal="AllEnemiesDefeated" from="YSort/Actors/GrannySpawner" to="." method="_on_GrannySpawner_AllEnemiesDefeated"]

--- a/Untitled Game/src/Levels/Streets.tscn
+++ b/Untitled Game/src/Levels/Streets.tscn
@@ -1228,6 +1228,7 @@ one_shot = true
 [connection signal="body_entered" from="LevelBackground/Interactions/LeaveLevel" to="." method="_on_LeaveLevel_body_entered"]
 [connection signal="SpawnWarning" from="YSort/TrafficSystemRight" to="." method="_on_TrafficSystemRight_SpawnWarning"]
 [connection signal="SpawnWarning" from="YSort/TrafficSystemLeft" to="." method="_on_TrafficSystemLeft_SpawnWarning"]
+[connection signal="died" from="YSort/Actors/LirikYaki" to="GUI/PauseScreenContainer" method="_on_player_died"]
 [connection signal="lockout_finished" from="YSort/Actors/AreaLockFightBoss" to="." method="_on_AreaLockFightBoss_lockout_finished"]
 [connection signal="lockout_started" from="YSort/Actors/AreaLockFightBoss" to="." method="_on_AreaLockFightBoss_lockout_started"]
 [connection signal="spawned" from="YSort/Actors/AreaLockFightBoss/Boss" to="." method="_on_Boss_spawned"]


### PR DESCRIPTION
connected player death signal to pause container in each level. 
activated when player dies, and deactivates menu interact till restart